### PR TITLE
Bump axios to >=0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/AmyrAhmady/steamdb-js#readme",
   "dependencies": {
-    "axios": "^0.19.1",
+    "axios": "^0.21.1",
     "cheerio": "^1.0.0-rc.3"
   }
 }


### PR DESCRIPTION
axios package before `0.21.1` contains a Server-Side Request Forgery (SSRF).
More info: https://www.npmjs.com/advisories/1594