### PR TITLE
Update Name and Date Grabbing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -95,7 +95,7 @@ export class Depot {
     * @Note must be used after `parse()`
     * @return depot info
     */
-   getDepotInfo(): { id: string, buildId: string, manifestId: string, creationDate: number, lastUpdate: number, size: string, downloadSize: string };
+   getDepotInfo(): { name: string, id: string, buildId: string, manifestId: string, creationDate: number, lastUpdate: number, size: string, downloadSize: string };
 }
 
 declare module 'steamdb-js';

--- a/src/depot.js
+++ b/src/depot.js
@@ -58,6 +58,9 @@ class Depot {
 
     async _parseDepotInformation(pageData) {
         let depotInfo = {};
+
+        depotInfo.name = await pageData('h1').text();
+
         await pageData('.table-hover > tbody > tr').each((_, element) => {
             let tableInfo = pageData(element).find('td').toArray();
             if (pageData(tableInfo[0]).text() == "Depot ID") {

--- a/src/depot.js
+++ b/src/depot.js
@@ -70,13 +70,11 @@ class Depot {
                 depotInfo.manifestId = Number(pageData(tableInfo[1]).text());
             }
             else if (pageData(tableInfo[0]).text() == "Creation date") {
-                let rawTime = pageData(tableInfo[1]).text().replace("()", " ").trim().split(' – ');
-                let time = new Date(rawTime[0] + ' ' + rawTime[1]);
+                let time = new Date(pageData(tableInfo[1]).find('time').attr('datetime'));
                 depotInfo.creationDate = time.getTime();
             }
             else if (pageData(tableInfo[0]).text() == "Last update") {
-                let rawTime = pageData(tableInfo[1]).text().replace("()", " ").trim().split(' – ');
-                let time = new Date(rawTime[0] + ' ' + rawTime[1]);
+                let time = new Date(pageData(tableInfo[1]).find('time').attr('datetime'));
                 depotInfo.lastUpdate = time.getTime();
             }
             else if (pageData(tableInfo[0]).text() == "Size on disk") {

--- a/src/game.js
+++ b/src/game.js
@@ -66,6 +66,9 @@ class Game {
 
     async _parseGameInformation(pageData) {
         let gameInfo = {};
+        
+        gameInfo.name = await pageData('h1[itemprop="name"]').text();
+
         await pageData('.table-dark > tbody > tr').each((_, element) => {
             let tableInfo = pageData(element).find('td').toArray();
             if (pageData(tableInfo[0]).text() == "App ID") {
@@ -83,9 +86,6 @@ class Game {
             else if (pageData(tableInfo[0]).text() == "Last Record Update") {
                 let time = new Date(pageData(tableInfo[1]).find("time").attr("datetime"));
                 gameInfo.lastUpdate = time.getTime();
-            }
-            else if (pageData(tableInfo[0]).text() == "Name") {
-                gameInfo.name = pageData(tableInfo[1]).text();
             }
             else if (pageData(tableInfo[0]).text() == "Release Date") {
                 let time = new Date(pageData(tableInfo[1]).find("time").attr("datetime"));

--- a/src/game.js
+++ b/src/game.js
@@ -66,7 +66,7 @@ class Game {
 
     async _parseGameInformation(pageData) {
         let gameInfo = {};
-        
+
         gameInfo.name = await pageData('h1[itemprop="name"]').text();
 
         await pageData('.table-dark > tbody > tr').each((_, element) => {
@@ -78,10 +78,10 @@ class Game {
                 gameInfo.type = pageData(tableInfo[1]).text();
             }
             else if (pageData(tableInfo[0]).text() == "Developer") {
-                gameInfo.developer = pageData(tableInfo[1]).text();
+                gameInfo.developer = pageData(tableInfo[1]).text().trim();
             }
             else if (pageData(tableInfo[0]).text() == "Publisher") {
-                gameInfo.publisher = pageData(tableInfo[1]).text();
+                gameInfo.publisher = pageData(tableInfo[1]).text().trim();
             }
             else if (pageData(tableInfo[0]).text() == "Last Record Update") {
                 let time = new Date(pageData(tableInfo[1]).find("time").attr("datetime"));

--- a/src/game.js
+++ b/src/game.js
@@ -81,14 +81,14 @@ class Game {
                 gameInfo.publisher = pageData(tableInfo[1]).text();
             }
             else if (pageData(tableInfo[0]).text() == "Last Record Update") {
-                let time = new Date(pageData(tableInfo[1]).find("span").attr("title"));
+                let time = new Date(pageData(tableInfo[1]).find("time").attr("datetime"));
                 gameInfo.lastUpdate = time.getTime();
             }
             else if (pageData(tableInfo[0]).text() == "Name") {
                 gameInfo.name = pageData(tableInfo[1]).text();
             }
             else if (pageData(tableInfo[0]).text() == "Release Date") {
-                let time = new Date(pageData(tableInfo[1]).find("span").attr("title"));
+                let time = new Date(pageData(tableInfo[1]).find("time").attr("datetime"));
                 gameInfo.releaseDate = time.getTime();
             }
             else if (pageData(tableInfo[0]).text() == "Supported Systems") {


### PR DESCRIPTION
* Update name grabbing for game since `name` is now located outside of the table. fixes #7
* Added name grabbing for depot
* Minor edit to trim trailing whitespace from the game `publisher` and `developer` caused by the search icon